### PR TITLE
prune list of available translations to English, only

### DIFF
--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -9,4 +9,19 @@ module HyraxHelper
     text = field[:value].join("\n\n")
     DataCatalog::MarkdownService.call(text).html_safe
   end
+
+  # import hyrax method
+  # Which translations are available for the user to select
+  # @return [Hash{String => String}] locale abbreviations as keys and flags as values
+  def available_translations
+    {
+      'de' => 'Deutsch',
+      'en' => 'English',
+      'es' => 'Español',
+      'fr' => 'Français',
+      'it' => 'Italiano',
+      'pt-BR' => 'Português do Brasil',
+      'zh' => '中文'
+    }
+  end
 end

--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -10,18 +10,12 @@ module HyraxHelper
     DataCatalog::MarkdownService.call(text).html_safe
   end
 
-  # import hyrax method
+  # override hyrax method
   # Which translations are available for the user to select
   # @return [Hash{String => String}] locale abbreviations as keys and flags as values
   def available_translations
     {
-      'de' => 'Deutsch',
-      'en' => 'English',
-      'es' => 'Español',
-      'fr' => 'Français',
-      'it' => 'Italiano',
-      'pt-BR' => 'Português do Brasil',
-      'zh' => '中文'
+      'en' => 'English'
     }
   end
 end


### PR DESCRIPTION
This drops the locale picker from the UI, as it only displays itself if the available translation count is greater than 1