### PR TITLE
remove login link from toolbar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,3 +74,4 @@ gem 'riiif', '~> 2.1'
 
 gem 'localhost'
 gem 'redcarpet'
+gem 'repost'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -771,6 +771,7 @@ GEM
     regexp_parser (2.9.0)
     reline (0.5.2)
       io-console (~> 0.5)
+    repost (0.4.2)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -987,6 +988,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.7, >= 6.1.7.7)
   redcarpet
+  repost
   riiif (~> 2.1)
   rsolr (>= 1.0, < 3)
   rspec-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,5 +9,7 @@ class ApplicationController < ActionController::Base
   include Hyrax::ThemedLayoutController
   with_themed_layout '1_column'
 
-
+  def login
+    redirect_post('/users/auth/cas', options: {authenticity_token: :auto})
+  end
 end

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -18,10 +18,6 @@
       </div>
     </li>
   <% else %>
-    <li class="nav-item">
-      <%= link_to main_app.user_cas_omniauth_authorize_path, method: :post, class: 'nav-link' do %>
-        <span class="fa fa-sign-in" aria-hidden="true"></span> <%= t("hyrax.toolbar.profile.login") %>
-      <% end %>
-    </li>
+    <%# drop login link %>
   <% end %>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,5 +35,7 @@ Rails.application.routes.draw do
       delete 'clear'
     end
   end
+
+  get '/login', to: 'application#login', as: 'login_url'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
* Adds the `repost` gem to allow for redirecting a GET login action to a (necessary) POST
* adds `/login` action, to provide to need-to-know users
* removes the sign_in action from the UI