### PR TITLE
[IULRDC-33] use markdown textarea for rights_notes (access instructions)

### DIFF
--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,7 +1,7 @@
 <%= presenter.attribute_to_html(:abstract, label: 'Summary', render_as: :markdown, html_dl: true) %>
 <%#= presenter.attribute_to_html(:description, label: 'Description', render_as: :markdown, html_dl: true) %>
 <%= presenter.attribute_to_html(:related_url, label: 'Documentation', render_as: :external_link, html_dl: true) %>
-<%= presenter.attribute_to_html(:rights_notes, label: 'Access Instructions', html_dl: true) %>
+<%= presenter.attribute_to_html(:rights_notes, label: 'Access Instructions', render_as: :markdown, html_dl: true) %>
 <%= presenter.attribute_to_html(:time_period, label: 'Timeframe', html_dl: true) %>
 <%= presenter.attribute_to_html(:subject, label: 'Keyword Subject', html_dl: true) %>
 <%= presenter.attribute_to_html(:geographic_location, label: 'Spatial Subject', html_dl: true) %>

--- a/app/views/records/edit_fields/_rights_notes.html.erb
+++ b/app/views/records/edit_fields/_rights_notes.html.erb
@@ -1,0 +1,5 @@
+<% if f.object.multiple? key %>
+  <%= f.input :rights_notes, as: :multi_value, input_html: { rows: '14', type: 'textarea'}, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input :rights_notes, as: :text, input_html: { rows: '14' }, required: f.object.required?(key) %>
+<% end %>


### PR DESCRIPTION
In draft status pending PO decision on retaining or unifying "Rights notes" vs "Access Instructions" labels