### PR TITLE
[IULRDC-31] re-label and provide hints for Edit fields

### DIFF
--- a/app/views/records/edit_fields/_default.html.erb
+++ b/app/views/records/edit_fields/_default.html.erb
@@ -1,0 +1,5 @@
+<% if f.object.multiple? key %>
+  <%= f.input key, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input key, required: f.object.required?(key) %>
+<% end %>

--- a/app/views/records/edit_fields/_default.html.erb
+++ b/app/views/records/edit_fields/_default.html.erb
@@ -1,5 +1,5 @@
 <% if f.object.multiple? key %>
-  <%= f.input key, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
+  <%= f.input key, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(key), hint: auto_link(I18n.t("simple_form.hints.data_set.#{key}")) %>
 <% else %>
-  <%= f.input key, required: f.object.required?(key) %>
+  <%= f.input key, required: f.object.required?(key),  hint: auto_link(I18n.t("simple_form.hints.data_set.#{key}")) %>
 <% end %>

--- a/app/views/records/edit_fields/_subject.html.erb
+++ b/app/views/records/edit_fields/_subject.html.erb
@@ -1,0 +1,8 @@
+<%= f.input key,
+            as: :multi_value,
+            input_html: {
+              class: 'form-control',
+              data: { 'autocomplete-url' => "/authorities/search/local/subjects",
+                      'autocomplete' => key }
+            },
+            required: f.object.required?(key) %>

--- a/app/views/records/edit_fields/_subject.html.erb
+++ b/app/views/records/edit_fields/_subject.html.erb
@@ -5,4 +5,5 @@
               data: { 'autocomplete-url' => "/authorities/search/local/subjects",
                       'autocomplete' => key }
             },
+            hint: auto_link(I18n.t("simple_form.hints.data_set.#{key}")),
             required: f.object.required?(key) %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -43,3 +43,47 @@ en:
     institution_name_full: Indiana University
     product_name: Research Data Catalog
     product_twitter_handle: "@SamveraRepo"
+  simple_form:
+    hints:
+      data_set:
+        title: 'Title of dataset'
+        abstract: 'Provide a short (one-sentence) description of the dataset, which will appear on the search results page.'
+        related_url: 'Provide a link to access the documentation for the dataset'
+        rights_notes: 'List the process or steps required to access the dataset'
+        time_period: 'Provide the year(s) or range of years of available data within the dataset, e.g. 1990-2010.'
+        subject: 'List key subject terms related to the dataset, using the Library of Congress Subject Headings (https://id.loc.gov/authorities/subjects.html)'
+        geographic_location: 'Describe the geographic location(s) covered in dataset, e.g. "United States," "Indiana"'
+        domain_subject: 'List one or more broad subject areas from the following list: https://go.iu.edu/8sqi'
+        creator: 'The group or individual who created the dataset, if applicable.'
+        description: 'Provide an abstract- or paragraph-length description of the dataset. You may use Markdown to incorporate formatting, and/or hyperlinks (This description should be longer than the one-sentence that will show up on the search results page, and will show up on the dataset page).'
+        location_physical: 'List the location(s) where the data are stored, e.g. "Cloud," "Slate Project"'
+        digital_specifications: 'List the format(s) of data files. Example: CSV, SAS, text'
+        expert: 'Provide the name and email of person or people to reach out to for questions about the dataset, formatted as follows: John Doe (jdoe@iu.edu).'
+        holding_location: 'Provide the campus unit(s) hosting the dataset, such as the school, department, or institute that purchased the dataset and/or is facilitating access.'
+        source_identifier: # (N/A - source identifier is the unique identifier for the data catalog, so nothing for depositors to enter? Confirm that this is correct.)
+        source : # (Same as above)
+        source_metadata_identifier: # (Same as above)
+        campus: 'Select all IU campuses able to access the dataset'
+        rights_statement: 'Select all categories of users that are eligible to access the data. (If there are additional restrictions, e.g. graduate students can access the data with an approved project, select "graduate students" here, and add additional information under Access Instructions (rights_notes)'
+        bibliographic_citation: 'Provide the bibliographic citation for the dataset, if applicable. Use Chicago style (https://iu.libguides.com/citation/chicago)'
+    labels:
+      defaults:
+        abstract: 'Summary'
+        related_url: 'Documentation'
+        rights_notes: 'Access instructions'
+        time_period: 'Timeframe'
+        subject: 'Keyword subject'
+        geographic_location: 'Spatial subject'
+        # domain_subject: 'Domain subject' # unchanged
+        # creator: 'Creator' # unchanged
+        # description: "Description' # unchanged
+        location_physical: 'Data location'
+        digital_specifications: 'File format(s)'
+        expert: 'Public contact'
+        holding_location: 'Hosting unit'
+        # source_identifier: 'Source identifier' # not displayed, unchanged
+        # source: 'Source" # not displayed, unchanged
+        # source_metadata_identifier: 'Source metadata identifier' # not displayed, unchanged
+        # campus: 'Campus' # unchanged
+        rights_statement: 'Access restrictions'
+        bibliographic_citation: 'Bibliographic citation'


### PR DESCRIPTION
First commit just configures field labels, hints and should be unobjectionable.

The next 2 commits are potentially objectionable.  They import then override hyrax partials so that we can `auto_link`  any URLs in the `hint` text -- there probably is, or ought to be, a more elegant way to do that via `SimpleForm` but I stopped trying that route after burning some time on it.  Alternatives to these commits include refactoring, or just dropping the linking behavior.