### PR TITLE
[IULRDC-39] Add field for Featured Data courses

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -31,6 +31,7 @@ class SolrDocument
   attribute :abstract, Solr::Array, "abstract_tesim"
   attribute :description, Solr::Array, "description_tesim"
   attribute :related_url, Solr::Array, "related_url_tesim"
+  attribute :references, Solr::Array, "references_tesim"
   attribute :rights_notes, Solr::Array, "rights_notes_tesim"
   attribute :time_period, Solr::Array, "time_period_tesim"
   attribute :subject, Solr::Array, "subject_tesim"

--- a/app/presenters/hyrax/data_set_presenter.rb
+++ b/app/presenters/hyrax/data_set_presenter.rb
@@ -1,6 +1,6 @@
 module Hyrax
   class DataSetPresenter < Hyrax::WorkShowPresenter
-    delegate :abstract, :description, :related_url, :rights_notes, :time_period, :subject,
+    delegate :abstract, :description, :related_url, :references, :rights_notes, :time_period, :subject,
              :geographic_location, :domain_subject, :creator, :location_physical, :digital_specifications,
              :expert, :holding_location, :campus, :rights_statement, :bibliographic_citations,
              to: :solr_document

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,6 +1,7 @@
 <%#= presenter.attribute_to_html(:abstract, label: 'Summary', render_as: :markdown, html_dl: true) %>
 <%#= presenter.attribute_to_html(:description, label: 'Description', render_as: :markdown, html_dl: true) %>
 <%= presenter.attribute_to_html(:related_url, label: 'Documentation', render_as: :external_link, html_dl: true) %>
+<%= presenter.attribute_to_html(:references, label: 'Featured Data/Canvas courses', render_as: :external_link, html_dl: true) %>
 <%= presenter.attribute_to_html(:rights_notes, label: 'Access Instructions', render_as: :markdown, html_dl: true) %>
 <%= presenter.attribute_to_html(:time_period, label: 'Timeframe', html_dl: true) %>
 <%= presenter.attribute_to_html(:subject, label: 'Keyword Subject', html_dl: true) %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -49,6 +49,7 @@ en:
         title: 'Title of dataset'
         abstract: 'Provide a short (one-sentence) description of the dataset, which will appear on the search results page. You may use basic Markdown for formatting and/or hyperlinks (https://www.markdownguide.org/cheat-sheet/#basic-syntax)'
         related_url: 'Provide a link to access the documentation for the dataset'
+        references: 'Provide a link to access the Featured Data/Canvas course for the dataset'
         rights_notes: 'List the process or steps required to access the dataset. You may use basic Markdown for formatting and/or hyperlinks (https://www.markdownguide.org/cheat-sheet/#basic-syntax)'
         time_period: 'Provide the year(s) or range of years of available data within the dataset, e.g. 1990-2010.'
         subject: 'List key subject terms related to the dataset, using the Library of Congress Subject Headings (https://id.loc.gov/authorities/subjects.html)'
@@ -70,6 +71,7 @@ en:
       defaults:
         abstract: 'Summary'
         related_url: 'Documentation'
+        references: 'Featured Data/Canvas course'
         rights_notes: 'Access instructions'
         time_period: 'Timeframe'
         subject: 'Keyword subject'

--- a/config/metadata/data_set.yaml
+++ b/config/metadata/data_set.yaml
@@ -47,6 +47,19 @@ attributes:
       primary: true
       multiple: true
 
+  references:
+    display_label: Featured Data/Canvas courses
+    predicate: http://purl.org/dc/terms/references
+    type: string
+    multiple: true
+    index_keys:
+      - 'references_tesim'
+      - 'references_sim'
+    form:
+      required: false
+      primary: true
+      multiple: true
+
   rights_notes:
     display_label: Access Instructions
     predicate: http://purl.org/dc/elements/1.1/rights


### PR DESCRIPTION
Adding a new field after the Documentation field and before the Access instructions field.  It is titled 'Featured Data/Canvas course' and the user can enter multiple values by adding more text boxes.  It uses the 'references' Dublin Core DCMI term.