### PR TITLE
[IULRDC-41] Use Access Restrictions terms not ids

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -54,7 +54,7 @@ class CatalogController < ApplicationController
     config.add_facet_field "domain_subject_sim", limit: 10, label: 'Domain Subject'
     config.add_facet_field "campus_sim", limit: 10, label: 'Campus', helper_method: :campus_label
     config.add_facet_field "holding_location_sim", limit: 10, label: 'Hosting Unit'
-    config.add_facet_field "rights_statement_sim", limit: 10, label: 'Access Restrictions'
+    config.add_facet_field "rights_statement_sim", limit: 10, label: 'Access Restrictions', helper_method: :access_restrictions_label
     # config.add_facet_field "human_readable_type_sim", label: "Type", limit: 5
     # config.add_facet_field "resource_type_sim", label: "Resource Type", limit: 5
     # config.add_facet_field "creator_sim", limit: 5

--- a/app/helpers/facet_helper.rb
+++ b/app/helpers/facet_helper.rb
@@ -3,6 +3,10 @@ module FacetHelper
     Hyrax::CampusService.new.label(value)
   end
 
+  def access_restrictions_label(value)
+    Hyrax::RightsStatementService.new.label(value)
+  end
+
   def campus_helper(**options)
     options[:value].map { |value| link_to_campus_facet(value, 'campus_sim') }.join("<br/>".html_safe).html_safe
   end

--- a/app/renderers/hyrax/renderers/access_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/access_attribute_renderer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Renderers
+    # This is used by PresentsAttributes to show access restrictions (faculty, staff, public etc.)
+    #   e.g.: presenter.attribute_to_html(:access render_as: :access)
+    class AccessAttributeRenderer < FacetedAttributeRenderer
+      private
+
+      #list on show page
+      def li_value(value)
+        link_to(ERB::Util.h(RightsStatementService.new.label(value)), search_path(value))
+      end
+
+    end
+  end
+end
+

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -12,5 +12,5 @@
 <%= presenter.attribute_to_html(:expert, label: 'Public Contact', html_dl: true) %>
 <%= presenter.attribute_to_html(:holding_location, label: 'Hosting Unit', render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:campus, label: 'Campus', render_as: :campus, html_dl: true) %>
-<%= presenter.attribute_to_html(:rights_statement, label: 'Access Restrictions', render_as: :faceted, html_dl: true) %>
+<%= presenter.attribute_to_html(:rights_statement, label: 'Access Restrictions', render_as: :access, html_dl: true) %>
 <%= presenter.attribute_to_html(:bibliographic_citation, label: 'Bibliographic Citation', html_dl: true) %>


### PR DESCRIPTION
Previously the Access Restrictions were correct on the edit page but not the view or search pages.  The single word Access Restrictions were lowercase i.e. 'faculty instead of 'Faculty' etc. and also appearing as just 'graduate' instead of 'Graduate Students' and 'undergraduate' instead of 'Undergraduate Students'.  RDC was using the ids instead of the terms from rights_statements.yml.  This is corrected here.