### PR TITLE
[IULRDC-37] Fix pagination number highlight

### DIFF
--- a/app/assets/stylesheets/rivet.tweaks.css
+++ b/app/assets/stylesheets/rivet.tweaks.css
@@ -22,6 +22,11 @@ a.page-link {
     color: #2e74b2;
 }
 
+.page-item.active .page-link {
+    background-color: #2e74b2;
+    border-color: #2e74b2;
+}
+
 a.page-link:hover{
     color: #00385f;
     text-decoration:underline;


### PR DESCRIPTION
 The blue highlighting the page number that the user is currently on is now the correct blue.  This change, like the previous one, affects the paging in the dashboard as well as the public search feature.