### PR TITLE
IULRDC-43 Hide the 'Attach Child' dropdown

### DIFF
--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -30,19 +30,7 @@
       <% if presenter.member_count > 1 %>
           <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-secondary' %>
       <% end %>
-      <% if presenter.valid_child_concerns.length > 0 %>
-        <div class="btn-group">
-          <button type="button" class="btn btn-secondary dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <%= t('.attach_child') %>
-            <ul class="dropdown-menu">
-              <% presenter.valid_child_concerns.each do |concern| %>
-                <li class="dropdown-item">
-                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
-                </li>
-              <% end %>
-            </ul>
-        </div>
-      <% end %>
+
       <%= link_to t('.delete'), [main_app, presenter], class: 'btn btn-danger', data: { confirm: t('.confirm_delete', work_type: presenter.human_readable_type) }, method: :delete %>
     <% end %>
   </div>

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -1,0 +1,54 @@
+<div class="row show-actions button-row-top-two-column">
+  <div class="col-sm-6">
+    <% if !workflow_restriction?(presenter) %>
+      <% if presenter.show_deposit_for?(collections: @user_collections) %>
+        <input type="checkbox" aria-label="Batch Documents" style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
+        <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
+                      class: 'btn btn-secondary submits-batches submits-batches-add',
+                      data: { toggle: "modal", target: "#collection-list-container" } %>
+      <% end %>
+      <% if presenter.work_featurable? %>
+        <%= link_to t('.feature'), hyrax.featured_work_path(presenter, format: :json),
+            data: { behavior: 'feature' },
+            class: presenter.display_feature_link? ? 'btn btn-secondary' : 'btn btn-secondary collapse' %>
+
+        <%= link_to t('.unfeature'), hyrax.featured_work_path(presenter, format: :json),
+            data: { behavior: 'unfeature' },
+            class: presenter.display_unfeature_link? ? 'btn btn-secondary' : 'btn btn-secondary collapse' %>
+      <% end %>
+    <% end %>
+    <% if Hyrax.config.analytics? %>
+      <% # turbolinks needs to be turned off or the page will use the cache and the %>
+      <% # analytics graph will not show unless the page is refreshed. %>
+      <%= link_to t('.analytics'), presenter.stats_path, id: 'stats', class: 'btn btn-secondary', data: { turbolinks: false } %>
+    <% end %>
+  </div>
+
+  <div class="col-sm-6 text-right">
+    <% if presenter.editor? && !workflow_restriction?(presenter) %>
+      <%= link_to t('.edit'), edit_polymorphic_path([main_app, presenter]), class: 'btn btn-secondary' %>
+      <% if presenter.member_count > 1 %>
+          <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-secondary' %>
+      <% end %>
+      <% if presenter.valid_child_concerns.length > 0 %>
+        <div class="btn-group">
+          <button type="button" class="btn btn-secondary dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <%= t('.attach_child') %>
+            <ul class="dropdown-menu">
+              <% presenter.valid_child_concerns.each do |concern| %>
+                <li class="dropdown-item">
+                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
+                </li>
+              <% end %>
+            </ul>
+        </div>
+      <% end %>
+      <%= link_to t('.delete'), [main_app, presenter], class: 'btn btn-danger', data: { confirm: t('.confirm_delete', work_type: presenter.human_readable_type) }, method: :delete %>
+    <% end %>
+  </div>
+</div>
+
+<!-- COinS hook for Zotero -->
+  <span class="Z3988" title="<%= export_as_openurl_ctx_kev(presenter) %>"></span>
+<!-- Render Modals -->
+  <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>


### PR DESCRIPTION
The 'Attach Data Set' option in the 'Attach Child' dropdown is not working and not needed, so hiding it for now.