### PR TITLE
[IULRDC-46] Hide unused sections from public

### DIFF
--- a/app/views/hyrax/data_sets/show.html.erb
+++ b/app/views/hyrax/data_sets/show.html.erb
@@ -27,24 +27,25 @@
       </div>
     </div><!-- /.card -->
 
-    <div class="card">
-      <div class="card-header">
-        <h2 class="card-title"><%= t('hyrax.base.show.relationships') %></h2>
+    <% if @presenter.editor? %>
+      <div class="card">
+        <div class="card-header">
+          <h2 class="card-title"><%= t('hyrax.base.show.relationships') %></h2>
+        </div>
+        <div class="card-body">
+          <%= render 'relationships', presenter: @presenter %>
+        </div>
       </div>
-      <div class="card-body">
-        <%= render 'relationships', presenter: @presenter %>
-      </div>
-    </div>
 
-    <div class="card">
-      <div class="card-header">
-        <h2 class="card-title"><%= t('.items') %></h2>
+      <div class="card">
+        <div class="card-header">
+          <h2 class="card-title"><%= t('.items') %></h2>
+        </div>
+        <div class="card-body">
+          <%= render 'items', presenter: @presenter %>
+        </div>
       </div>
-      <div class="card-body">
-        <%= render 'items', presenter: @presenter %>
-      </div>
-    </div>
-
+    <% end %>
     <%# TODO: we may consider adding these partials in the future %>
     <%# = render 'sharing_with', presenter: @presenter %>
     <%# = render 'user_activity', presenter: @presenter %>


### PR DESCRIPTION
Hiding the currently unused sections "Relations" and "Items" on the dataset/record listing/detail pages for users who do not have access to edit that dataset/record.