### PR TITLE
IULRDC-184 RDC: minor site fixes

### DIFF
--- a/app/assets/stylesheets/dashboard.tweaks.css
+++ b/app/assets/stylesheets/dashboard.tweaks.css
@@ -22,6 +22,10 @@ nav.breadcrumb a {
   align-content: center
 }
 
+.selected-facet {
+  margin-right: 1.5em;
+}
+
 /* Access eligibility (rights_statement) checkboxes */
 div.form-group.check_boxes {
   div.checkbox {

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -34,7 +34,6 @@
       <% unless @presenter.total_viewable_items.blank? %>
           <div class="hyc-bugs">
             <div class="hyc-item-count">
-              <b><%= @presenter.total_viewable_items %></b>
               <%= pluralize(@presenter.total_viewable_items, t('.item_count')) %></div>
 
             <% unless @presenter.creator.blank? %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -31,6 +31,15 @@ en:
           subject_tesim: Subject
           title_tesim: Title
   hyrax:
+    admin:
+      workflows:
+        index:
+          header: Review Submissions
+          heading:
+            work: Work
+            depositor: Depositor
+            submission_date: Submission Date
+            status: Status
     account_name: My Institution Account Id
     contact_form:
       notice: Please use the contact form to submit inquiries about this system; to report a problem you are experiencing with the system; to request assistance using the system; or to provide general feedback.


### PR DESCRIPTION
- collections and subcollections no longer display the number of items in the collection twice, just once
- the “Status" grid heading is now capitalized on the "Review Submissions" Dashboard page