### PR TITLE
IULRDC-186 RDC More SiteImprove accessibility changes

### DIFF
--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,23 +1,25 @@
-<ul id="user_utility_links" class="navbar-nav navbar-dark">
-  <%= render 'shared/locale_picker' if available_translations.size > 1 %>
-  <% if user_signed_in? %>
-    <li class="nav-item">
-      <%= render_notifications(user: current_user) %>
-    </li>
-    <li class="nav-item dropdown">
-      <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>
-        <span><%= current_user.name %></span>
-        <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>
-      </a>
-      <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-        <%= link_to "My Profile", hyrax.dashboard_profile_path(current_user), class: 'dropdown-item' %>
-        <%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path, class: "dropdown-item" %>
-        <div class="dropdown-divider"></div>
-        <%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path, class: "dropdown-item" %>
-      </div>
-    </li>
-  <% else %>
-    <%# drop login link %>
-  <% end %>
-</ul>
+<% if user_signed_in? || available_translations.size > 1 %>
+  <ul id="user_utility_links" class="navbar-nav navbar-dark">
+    <%= render 'shared/locale_picker' if available_translations.size > 1 %>
+    <% if user_signed_in? %>
+      <li class="nav-item">
+        <%= render_notifications(user: current_user) %>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>
+          <span><%= current_user.name %></span>
+          <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>
+        </a>
+        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+          <%= link_to "My Profile", hyrax.dashboard_profile_path(current_user), class: 'dropdown-item' %>
+          <%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path, class: "dropdown-item" %>
+          <div class="dropdown-divider"></div>
+          <%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path, class: "dropdown-item" %>
+        </div>
+      </li>
+    <% else %>
+      <%# drop login link %>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -4,7 +4,7 @@
     <% doc_presenter = index_presenter(document) %>
     <% index_fields(document).each do |field_name, field| -%>
       <% if should_render_index_field? document, field %>
-        <div class="row">
+        <div class="row search_results_show">
           <dd class="col-12"><%= doc_presenter.field_value field %></dd>
         </div>
       <% end %>


### PR DESCRIPTION
- adding underlines for hyperlinks in the "description" and "access instructions" fields of a Data Set.  SiteImprove.com complains links in these areas "are not clearly identifiable"
- Now only showing the UL element for the "All" button next to the search bar when the "All" button is visible (and has LI tags).  SiteImprove.com complains that "container element is empty" otherwise.