### PR TITLE
[IULRDC-198] bugfix: dashboard AdminSet select

### DIFF
--- a/app/views/hyrax/my/_constraints.html.erb
+++ b/app/views/hyrax/my/_constraints.html.erb
@@ -1,0 +1,13 @@
+<% if query_has_constraints? %>
+  <div id="appliedParams" class="clearfix constraints-container">
+    <div class="float-right">
+      <%= link_to start_over_path,
+          class: "catalog_startOverLink btn btn-sm btn-text", id: "startOverLink" do %>
+          <span class="btn btn-sm btn-danger start-over"><span class="fa fa-times"></span></span>
+          <%= t('blacklight.search.start_over') %>
+      <% end %>
+    </div>
+    <span class="constraints-label"><%= t('blacklight.search.filters.title') %></span>
+    <%= render_constraints(params.merge(route_set: hyrax)) %>
+  </div>
+<% end %>

--- a/app/views/hyrax/my/_constraints.html.erb
+++ b/app/views/hyrax/my/_constraints.html.erb
@@ -10,4 +10,11 @@
     <span class="constraints-label"><%= t('blacklight.search.filters.title') %></span>
     <%= render_constraints(params.merge(route_set: hyrax)) %>
   </div>
+
+<script type="application/javascript">
+    $(function() {
+      $("span.applied-filter span:contains(\"Hyrax::AdministrativeSet\")").text("Admin Set").attr('title', 'Admin Set');
+    });
+</script>
+
 <% end %>

--- a/app/views/hyrax/my/collections/_facets.html.erb
+++ b/app/views/hyrax/my/collections/_facets.html.erb
@@ -1,0 +1,9 @@
+<% # main container for facets/limits menu -%>
+<% facets = capture do %>
+  <%= render Blacklight::FacetComponent.with_collection(blacklight_config.facet_fields_in_group(nil), response: @response, component: Hyrax::DropdownFacetFieldComponent)%>
+<% end %>
+
+<div class="list-filters" role="group">
+  <span class="list-filters-label"><%= t("hyrax.dashboard.my.facet_label.collections") %></span>
+  <%= facets %>
+</div>

--- a/app/views/hyrax/my/collections/_facets.html.erb
+++ b/app/views/hyrax/my/collections/_facets.html.erb
@@ -7,3 +7,17 @@
   <span class="list-filters-label"><%= t("hyrax.dashboard.my.facet_label.collections") %></span>
   <%= facets %>
 </div>
+
+<script type="application/javascript">
+  $("button#collection_type_gid_ssim").click(function() {
+    $("ul#collection_type_gid_ssim-dropdown-options a:contains(\"Admin Set\")").closest("li.dropdown-item").remove();
+    $("ul#collection_type_gid_ssim-dropdown-options a:contains(\"Hyrax::AdministrativeSet\")").text("Admin  Set");
+
+    let selected_facet = $("ul#collection_type_gid_ssim-dropdown-options span:contains(\"Hyrax::AdministrativeSet\")")
+    if (selected_facet !== null) {
+        selected_facet.text("Admin Set");
+        selected_facet.after("<a class=\"selected-facet\" rel=\"nofollow\" href=\"/dashboard/collections?locale=en&amp;route_set=%23%3CActionDispatch%3A%3ARouting%3A%3ARoutesProxy%3A0x00007f6b5c926bd8%3E\"><span class=\"remove-icon\" aria-hidden=\"true\">✖</span><span class=\"sr-only visually-hidden\">[remove]</span></a>");
+    }
+
+  });
+</script>


### PR DESCRIPTION
In draft status pending investigation of why this isn't happening on my localhost, and if its fixable via solr indexing

- Admin Set appears only once in the Collection Type filtering dropdown on the Collections pages on the Dashboard.  Previously it appeared twice, as “Admin Set” and as “Hyrax::AdministrativeSet”
UPDATE: got it to happen on localhost; see follow-up comments