### PR TITLE
IULRDC-203: RDC 'Transfer work' feature disable option fix

### DIFF
--- a/app/views/hyrax/my/_work_action_menu.html.erb
+++ b/app/views/hyrax/my/_work_action_menu.html.erb
@@ -1,0 +1,45 @@
+<% ul_id = 'admin-set-action-dropdown-ul-' + document.id %>
+
+<div class="btn-group">
+
+  <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= document.id %>" aria-haspopup="true" aria-expanded="false" aria-controls="<%= ul_id %>">
+    <span class="sr-only"><%= t("hyrax.dashboard.my.sr.press_to") %> </span>
+    <%= t("hyrax.dashboard.my.action.select") %>
+  </button>
+
+  <ul role="menu" id="<%= ul_id %>" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= document.id %>">
+
+    <% if can? :edit, document.id %>
+      <li class="dropdown-item" role="menuitem" tabindex="-1">
+        <%= link_to [main_app, :edit, document],
+                    id: 'action-edit-work' do %>
+          <%= t("hyrax.dashboard.my.action.edit_work") %>
+        <% end %>
+      </li>
+
+      <li class="dropdown-item" role="menuitem" tabindex="-1">
+        <%= link_to [main_app, document],
+                    method: :delete,
+                    id: 'action-delete-work',
+                    data: {
+                      confirm: t("hyrax.dashboard.my.action.work_confirmation", application_name: application_name) } do %>
+          <%= t("hyrax.dashboard.my.action.delete_work") %>
+        <% end %>
+      </li>
+    <% end %>
+
+    <li class="dropdown-item" role="menuitem" tabindex="-1">
+      <%= display_trophy_link(current_user, document.id) do |text| %>
+        <%= text %>
+      <% end %>
+    </li>
+
+    <% if can? :transfer, document.id %>
+      <li class="dropdown-item" role="menuitem" tabindex="-1">
+        <%= link_to(hyrax.new_work_transfer_path(document.id), id: 'action-transfer-work', class: 'itemicon itemtransfer', title: t("hyrax.dashboard.my.action.transfer")) do %>
+          <%= t("hyrax.dashboard.my.action.transfer") %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/hyrax/my/_work_action_menu.html.erb
+++ b/app/views/hyrax/my/_work_action_menu.html.erb
@@ -34,7 +34,7 @@
       <% end %>
     </li>
 
-    <% if can? :transfer, document.id %>
+    <% if (can? :transfer, document.id) && Flipflop.enabled?(:transfer_works) %>
       <li class="dropdown-item" role="menuitem" tabindex="-1">
         <%= link_to(hyrax.new_work_transfer_path(document.id), id: 'action-transfer-work', class: 'itemicon itemtransfer', title: t("hyrax.dashboard.my.action.transfer")) do %>
           <%= t("hyrax.dashboard.my.action.transfer") %>

--- a/app/views/hyrax/transfers/new.html.erb
+++ b/app/views/hyrax/transfers/new.html.erb
@@ -1,0 +1,16 @@
+<% provide :page_header do %>
+  <h1><span class="fa fa-arrows-h" aria-hidden="true"></span><%= t(:'.title', work_title: @proxy_deposit_request.to_s) %></h1>
+<% end %>
+
+<span class="sr-only"><%= t(:'.sr_only_description', work_title: @proxy_deposit_request.to_s) %></span>
+
+<%= simple_form_for @proxy_deposit_request,
+             url: hyrax.work_transfers_path(params[:id]) do |f| %>
+  <%= f.input :transfer_to,
+        placeholder: t(:'.placeholder') %>
+  <%= f.input :sender_comment %>
+
+  <div class="form-actions">
+    <%= f.submit class: 'btn btn-primary', data: { confirm: t('.confirm') } %>
+  </div>
+<% end %>

--- a/app/views/hyrax/transfers/new.html.erb
+++ b/app/views/hyrax/transfers/new.html.erb
@@ -4,13 +4,19 @@
 
 <span class="sr-only"><%= t(:'.sr_only_description', work_title: @proxy_deposit_request.to_s) %></span>
 
-<%= simple_form_for @proxy_deposit_request,
-             url: hyrax.work_transfers_path(params[:id]) do |f| %>
-  <%= f.input :transfer_to,
-        placeholder: t(:'.placeholder') %>
-  <%= f.input :sender_comment %>
+<% if Flipflop.transfer_works? %>
 
-  <div class="form-actions">
-    <%= f.submit class: 'btn btn-primary', data: { confirm: t('.confirm') } %>
-  </div>
+  <%= simple_form_for @proxy_deposit_request, url: hyrax.work_transfers_path(params[:id]) do |f| %>
+    <%= f.input :transfer_to, placeholder: t(:'.placeholder') %>
+    <%= f.input :sender_comment %>
+
+    <div class="form-actions">
+      <%= f.submit class: 'btn btn-primary', data: { confirm: t('.confirm') } %>
+    </div>
+  <% end %>
+
+<% else %>
+
+    <p class="center"><%= t('.disabled') %></p>
+
 <% end %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -61,6 +61,9 @@ en:
         missing: There are no active embargoes in effect at this time.
       list_deactivated_embargoes:
         missing: There are no deactivated embargoes.
+    transfers:
+      new:
+        disabled: Transferring ownership of works is not allowed at this time.
   simple_form:
     hints:
       data_set:


### PR DESCRIPTION
Disabling the 'Transfer work' feature under  Configuration -> Settings -> Features  now hides the 'Transfer ownership of work' option on the Actions menu on the 'All Works' and 'Your Works' Dashboard pages.

In addition, navigating directly to the 'Transfer Ownership of [Work Title]' page results in the user seeing the 'Transferring ownership of works is not allowed at this time.' message instead of the transfer form.