### PR TITLE
IULRDC-205 RDC: Fix disabling 'Manage Proxies' feature

### DIFF
--- a/app/views/hyrax/dashboard/_index_partials/_proxy_rights.html.erb
+++ b/app/views/hyrax/dashboard/_index_partials/_proxy_rights.html.erb
@@ -1,34 +1,43 @@
 <div class="clearfix proxy-rights">
-  <div class="row">
-    <div class="col-12">
-      <p><%= t('hyrax.dashboard.proxy_help') %></p>
+  
+  <% if Flipflop.enabled?(:proxy_deposit) %>
+    <div class="row">
+      <div class="col-12">
+        <p><%= t('hyrax.dashboard.proxy_help') %></p>
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-6 proxy-search">
-      <h2><%= t("hyrax.dashboard.authorize_proxies") %></h2>
-      <div class="form-group">
-        <label for="user"><%= t("hyrax.dashboard.proxy_user") %></label>
-        <%= hidden_field_tag :user, nil, data: { grantor: current_user.to_param } %>
-        <%= hidden_field_tag :delete_button_label, nil, data: { label: I18n.t('hyrax.dashboard.proxy_delete') } %>
+    <div class="row">
+      <div class="col-6 proxy-search">
+        <h2><%= t("hyrax.dashboard.authorize_proxies") %></h2>
+        <div class="form-group">
+          <label for="user"><%= t("hyrax.dashboard.proxy_user") %></label>
+          <%= hidden_field_tag :user, nil, data: { grantor: current_user.to_param } %>
+          <%= hidden_field_tag :delete_button_label, nil, data: { label: I18n.t('hyrax.dashboard.proxy_delete') } %>
+        </div>
+      </div>
+
+      <div class="col-6">
+        <h2><%= t("hyrax.dashboard.current_proxies") %></h2>
+        <% if user.can_receive_deposits_from.count > 0 %>
+          <table class="table table-sm table-striped" id="authorizedProxies">
+            <tbody>
+            <% user.can_receive_deposits_from.each do |depositor| %>
+                <tr><td class="depositor-name"><%= depositor.name %></td>
+                  <td><%= link_to(I18n.t('hyrax.dashboard.proxy_delete'), hyrax.user_depositor_path(user, depositor),
+                                  method: :delete,
+                                  class: "remove-proxy-button btn btn-danger") %>
+                  </td></tr>
+            <% end %>
+            </tbody>
+          </table>
+        <% end %>
       </div>
     </div>
 
-    <div class="col-6">
-      <h2><%= t("hyrax.dashboard.current_proxies") %></h2>
-      <% if user.can_receive_deposits_from.count > 0 %>
-        <table class="table table-sm table-striped" id="authorizedProxies">
-          <tbody>
-          <% user.can_receive_deposits_from.each do |depositor| %>
-              <tr><td class="depositor-name"><%= depositor.name %></td>
-                <td><%= link_to(I18n.t('hyrax.dashboard.proxy_delete'), hyrax.user_depositor_path(user, depositor),
-                                method: :delete,
-                                class: "remove-proxy-button btn btn-danger") %>
-                </td></tr>
-          <% end %>
-          </tbody>
-        </table>
-      <% end %>
-    </div>
-  </div>
+  <% else %>
+
+    <p><%= t('hyrax.dashboard.proxy_disabled') %></p>
+
+  <% end %>
+
 </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -54,6 +54,8 @@ en:
     product_twitter_handle: "@SamveraRepo"
     controls:
       home: Catalog Home
+    dashboard:
+      proxy_disabled: Proxy management is currently disabled.
     embargoes:
       list_active_embargoes:
         missing: There are no active embargoes in effect at this time.


### PR DESCRIPTION
Previously turning off the 'Proxy deposit' RDC feature only hid the 'Manage Proxies' page in the Dashboard menu.  Now if the user has the page bookmarked and navigates there independently, the form on the page is disabled and the page shows a 'disabled' message.